### PR TITLE
fix sudden fps drop

### DIFF
--- a/1.16.5/randompatches.toml
+++ b/1.16.5/randompatches.toml
@@ -318,10 +318,10 @@
 		# Fixes duplicate entity UUIDs by assigning new UUIDs to the affected entities.
 		# This bug is reported as MC-95649: https://bugs.mojang.com/browse/MC-95649
 		# Default: true
-		fix_duplicate_entity_uuids = true
+		fix_duplicate_entity_uuids = false
 		# Logs fixed entity UUIDs.
 		# Default: true
-		log_fixed_duplicate_entity_uuids = true
+		log_fixed_duplicate_entity_uuids = false
 		# Fixes the recipe book not automatically moving ingredients with NBT tags to the crafting grid.
 		# This bug is reported as MC-129057: https://bugs.mojang.com/browse/MC-129057
 		# Default: true


### PR DESCRIPTION
此修复的运作原理是监听区块加载事件然后切换实体uuid，看看源码稍微想想就知道了，很容易掉帧。
推荐用这个：https://www.mcmod.cn/class/5984.html
监听的是实体加入世界的事件，性能比这玩意高。